### PR TITLE
refactor: split services into subpackages

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/PersonController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/PersonController.java
@@ -14,7 +14,7 @@ import com.safetynet.safetynetalertsapi.model.Person;
 import com.safetynet.safetynetalertsapi.model.dto.ChildDTO;
 import com.safetynet.safetynetalertsapi.model.dto.PersonDTO;
 import com.safetynet.safetynetalertsapi.repositories.JsonDataProvider;
-import com.safetynet.safetynetalertsapi.services.PersonFinder;
+import com.safetynet.safetynetalertsapi.services.finders.PersonFinder;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/collectionutils/PersonFilterService.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/collectionutils/PersonFilterService.java
@@ -1,4 +1,4 @@
-package com.safetynet.safetynetalertsapi.services;
+package com.safetynet.safetynetalertsapi.services.collectionutils;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import com.safetynet.safetynetalertsapi.model.Identifiable;
 import com.safetynet.safetynetalertsapi.model.Identity;
 import com.safetynet.safetynetalertsapi.model.MedicalRecord;
+import com.safetynet.safetynetalertsapi.services.finders.MedicalRecordFinder;
 
 @Service
 public class PersonFilterService {

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/finders/FireStationFinder.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/finders/FireStationFinder.java
@@ -13,8 +13,7 @@ import com.safetynet.safetynetalertsapi.model.dto.CoveredPhoneDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationCoverageDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 import com.safetynet.safetynetalertsapi.repositories.JsonDataProvider;
-import com.safetynet.safetynetalertsapi.services.PersonFilterService;
-import com.safetynet.safetynetalertsapi.services.PersonFinder;
+import com.safetynet.safetynetalertsapi.services.collectionutils.PersonFilterService;
 import com.safetynet.safetynetalertsapi.services.mappers.FireStationMapper;
 import com.safetynet.safetynetalertsapi.services.validators.FireStationValidator;
 

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/finders/MedicalRecordFinder.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/finders/MedicalRecordFinder.java
@@ -1,4 +1,4 @@
-package com.safetynet.safetynetalertsapi.services;
+package com.safetynet.safetynetalertsapi.services.finders;
 
 import java.util.List;
 

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/finders/PersonFinder.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/finders/PersonFinder.java
@@ -1,4 +1,4 @@
-package com.safetynet.safetynetalertsapi.services;
+package com.safetynet.safetynetalertsapi.services.finders;
 
 import java.time.LocalDate;
 import java.time.Period;
@@ -17,6 +17,8 @@ import com.safetynet.safetynetalertsapi.model.dto.ChildDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FamilyMemberDTO;
 import com.safetynet.safetynetalertsapi.model.dto.PersonDTO;
 import com.safetynet.safetynetalertsapi.repositories.JsonDataProvider;
+import com.safetynet.safetynetalertsapi.services.collectionutils.PersonFilterService;
+import com.safetynet.safetynetalertsapi.services.mappers.PersonMapper;
 
 @Service
 public class PersonFinder {

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/PersonMapper.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/PersonMapper.java
@@ -1,4 +1,4 @@
-package com.safetynet.safetynetalertsapi.services;
+package com.safetynet.safetynetalertsapi.services.mappers;
 
 import java.util.List;
 import java.util.stream.Collectors;


### PR DESCRIPTION
Amélioration de l'organisation du code en créant des sous-packages dédiés pour différents types de services : 

 - mappers : regroupe les services responsables de la transformation des données entre différents types.
 - finders : contient les services dédiés à la recherche et récupération d'entités ou d'informations spécifiques.
 - validators : centralise les services responsables de la validation des données ou des règles métier.
 - collectionutils : classes utilitaires pour les opérations sur les collections (filtrage, tri, etc.).

Facilite la navigation dans le projet pour trouver rapidement une classe spécifique. 
