### PR TITLE
endpoint /fire

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.safetynet.safetynetalertsapi.exceptions.StationNotFoundException;
 import com.safetynet.safetynetalertsapi.model.dto.CoveredPhoneDTO;
+import com.safetynet.safetynetalertsapi.model.dto.FireAlertDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationCoverageDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 import com.safetynet.safetynetalertsapi.services.finders.FireStationFinder;
@@ -51,5 +52,11 @@ public class FireStationController {
 			logger.error(e.getMessage());
 			return ResponseEntity.status(HttpStatusCode.valueOf(404)).body(null);
 		}
+	}
+	
+	@GetMapping("/fire/{address}")
+	public ResponseEntity<FireAlertDTO> getFireAlertInfoByAddress(@PathVariable String address) {
+		FireAlertDTO fire = finder.getAllResidentsByAddress(address);
+		return ResponseEntity.ok(fire);
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
@@ -1,0 +1,64 @@
+package com.safetynet.safetynetalertsapi.model.dto;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.safetynet.safetynetalertsapi.model.Identifiable;
+import com.safetynet.safetynetalertsapi.model.Identity;
+
+public class AlertPersonInfoDTO implements Identifiable {
+	@JsonUnwrapped
+	private Identity identity;
+	private String phone;
+	private int age;
+	private List<String> allergies;
+	private List<String> medications;
+	
+	public AlertPersonInfoDTO(Identity identity, String phone, int age, List<String> allergies, List<String> medications) {
+		this.identity = identity;
+		this.phone = phone;
+		this.age = age;
+		this.allergies = allergies;
+		this.medications = medications;
+	}
+	
+	public Identity getIdentity() {
+		return identity;
+	}
+	
+	public void setIdentity(Identity identity) {
+		this.identity = identity;
+	}
+	
+	public String getPhone() {
+		return phone;
+	}
+	
+	public void setPhone(String phone) {
+		this.phone = phone;
+	}
+	
+	public int getAge() {
+		return age;
+	}
+	
+	public void setAge(int age) {
+		this.age = age;
+	}
+	
+	public List<String> getAllergies() {
+		return allergies;
+	}
+	
+	public void setAllergies(List<String> allergies) {
+		this.allergies = allergies;
+	}
+	
+	public List<String> getMedications() {
+		return medications;
+	}
+	
+	public void setMedications(List<String> medications) {
+		this.medications = medications;
+	}
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireAlertDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireAlertDTO.java
@@ -1,0 +1,34 @@
+package com.safetynet.safetynetalertsapi.model.dto;
+
+import java.util.List;
+
+public class FireAlertDTO {
+	private int stationNumber;
+	private List<AlertPersonInfoDTO> persons;
+	
+	public FireAlertDTO(int stationNumber, List<AlertPersonInfoDTO> persons) {
+		this.stationNumber = stationNumber;
+		this.persons = persons;
+	}
+	
+	public int getStationNumber() {
+		return stationNumber;
+	}
+	
+	public void setStationNumber(int stationNumber) {
+		this.stationNumber = stationNumber;
+	}
+	
+	public List<AlertPersonInfoDTO> getResidents() {
+		return persons;
+	}
+	
+	public void setResidents(List<AlertPersonInfoDTO> persons) {
+		this.persons = persons;
+	}
+	
+	@Override
+	public String toString() {
+		return this.stationNumber + this.persons.toString();
+	}
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/finders/FireStationFinder.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/finders/FireStationFinder.java
@@ -9,9 +9,12 @@ import org.springframework.stereotype.Service;
 import com.safetynet.safetynetalertsapi.exceptions.StationNotFoundException;
 import com.safetynet.safetynetalertsapi.model.FireStation;
 import com.safetynet.safetynetalertsapi.model.dto.CoveredPersonDTO;
+import com.safetynet.safetynetalertsapi.model.dto.AlertPersonInfoDTO;
 import com.safetynet.safetynetalertsapi.model.dto.CoveredPhoneDTO;
+import com.safetynet.safetynetalertsapi.model.dto.FireAlertDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationCoverageDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
+import com.safetynet.safetynetalertsapi.model.dto.PersonDTO;
 import com.safetynet.safetynetalertsapi.repositories.JsonDataProvider;
 import com.safetynet.safetynetalertsapi.services.collectionutils.PersonFilterService;
 import com.safetynet.safetynetalertsapi.services.mappers.FireStationMapper;
@@ -123,5 +126,20 @@ public class FireStationFinder {
 		.collect(Collectors.toList());
 		
 		return new CoveredPhoneDTO(stationNumber, coveredPhones);
+	}
+
+	public FireAlertDTO getAllResidentsByAddress(String address) {
+		List<PersonDTO> persons = personFinder.findAllPersonsByAddress(address);
+		
+		int stationNumber = getAllFireStations()
+				.stream()
+				.filter(fs -> fs.getAddress().replace(" ", "").equalsIgnoreCase(address))
+				.findAny()
+				.orElse(null)
+				.getStation();
+		
+		List<AlertPersonInfoDTO> residents = mapper.fromPersonDTOtoAlertPersonInfoDTO(persons);
+		
+		return new FireAlertDTO(stationNumber, residents);
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/FireStationMapper.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/FireStationMapper.java
@@ -1,17 +1,27 @@
 package com.safetynet.safetynetalertsapi.services.mappers;
 
+import java.time.LocalDate;
+import java.time.Period;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.safetynet.safetynetalertsapi.model.FireStation;
+import com.safetynet.safetynetalertsapi.model.Identity;
+import com.safetynet.safetynetalertsapi.model.MedicalRecord;
 import com.safetynet.safetynetalertsapi.model.dto.CoveredPersonDTO;
+import com.safetynet.safetynetalertsapi.model.dto.AlertPersonInfoDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 import com.safetynet.safetynetalertsapi.model.dto.PersonDTO;
+import com.safetynet.safetynetalertsapi.services.finders.MedicalRecordFinder;
 
 @Service
 public class FireStationMapper {
+	
+	@Autowired
+	MedicalRecordFinder medicalRecordFinder;
 	
 	public FireStationDTO fromFireStationToFireStationDTO(FireStation fireStation) {
 		return new FireStationDTO(fireStation.getAddress(), fireStation.getStation());
@@ -33,5 +43,20 @@ public class FireStationMapper {
 				.stream()
 				.map(this::fromPersonDTOToCoveredPersonDTO)
 				.collect(Collectors.toList());
+	}
+	
+	public List<AlertPersonInfoDTO> fromPersonDTOtoAlertPersonInfoDTO(List<PersonDTO> persons) {
+		List<AlertPersonInfoDTO> residents = persons.stream().map(person -> {
+			Identity identity = person.getIdentity();
+			MedicalRecord record = medicalRecordFinder.findByIdentity(identity);
+			String phone = person.getPhone();
+			int age = Period.between(record.getBirthDate(), LocalDate.now()).getYears();
+			List<String> allergies = record.getAllergies();
+			List<String> medications = record.getMedications();
+			return new AlertPersonInfoDTO(identity, phone, age, allergies, medications);
+		})
+		.collect(Collectors.toList());
+		
+		return residents;
 	}
 }


### PR DESCRIPTION
 - Ajout du endpoint GET getFireAlertInfoByAddress() dans FireStationController : 
permet de récupérer les informations sur les alertes incendie par adresse, y compris le numéro de station et les informations des résidents.

 - Création de DTO pour représenter : 
AlertPersonInfoDTO : Les personnes résidant à l'adresse donnée ; comprend nom complet, numéro de téléphone, âge, allergies et traitement médicamenteux. 
FireAlertDTO : les informations nécessaires pour réagir à une alerte au feu à l'adresse donnée (numéro de la station concernée, collection de AlertPersonInfo). 

 - Ajout de la méthode getAllResidentsByAddress() dans FireStationFinder : 
Récupère les informations des résidents par adresse. Elle utilise la méthode existante findAllPersonsByAddress() pour récupérer une liste de PersonDTO, puis la méthode fromPersonsDTOTOAlertPersonInfoDTO() du Mapper pour convertir ces informations en AlertPersonInfoDTO.
