### PR TITLE
Ajout du endpoint /flood/{stationNumbers}

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
@@ -16,6 +16,7 @@ import com.safetynet.safetynetalertsapi.model.dto.FireAlertDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationCoverageDTO;
 import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 import com.safetynet.safetynetalertsapi.services.finders.FireStationFinder;
+import com.safetynet.safetynetalertsapi.model.dto.FloodAlertDTO;
 
 @RestController
 public class FireStationController {
@@ -55,7 +56,13 @@ public class FireStationController {
 	
 	@GetMapping("/fire/{address}")
 	public ResponseEntity<FireAlertDTO> getFireAlertInfoByAddress(@PathVariable String address) {
-		FireAlertDTO fire = finder.getAllResidentsByAddress(address);
+		FireAlertDTO fire = finder.getFireAlertInfoByAddress(address);
 		return ResponseEntity.ok(fire);
+	}
+
+	@GetMapping("/flood/{stationNumbers}")
+	public ResponseEntity<?> getFloodAlertInfoByStations(@PathVariable List<Integer> stationNumbers) {
+		List<FloodAlertDTO> personsToAlert = finder.getFloodAlertInfoByStations(stationNumbers);
+		return ResponseEntity.ok(personsToAlert);
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
@@ -61,4 +61,9 @@ public class AlertPersonInfoDTO implements Identifiable {
 	public void setMedications(List<String> medications) {
 		this.medications = medications;
 	}
+
+	@Override
+	public String toString() {
+		return this.getIdentity().toString();
+	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FloodAlertDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FloodAlertDTO.java
@@ -1,0 +1,32 @@
+package com.safetynet.safetynetalertsapi.model.dto;
+
+import com.safetynet.safetynetalertsapi.model.Address;
+
+import java.util.List;
+
+public class FloodAlertDTO {
+    public String address;
+
+    public List<AlertPersonInfoDTO> persons;
+
+    public FloodAlertDTO(String address, List<AlertPersonInfoDTO> persons) {
+        this.address = address;
+        this.persons = persons;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public List<AlertPersonInfoDTO> getPersons() {
+        return persons;
+    }
+
+    public void setPersons(List<AlertPersonInfoDTO> persons) {
+        this.persons = persons;
+    }
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/finders/FireStationFinder.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/finders/FireStationFinder.java
@@ -1,25 +1,25 @@
 package com.safetynet.safetynetalertsapi.services.finders;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.safetynet.safetynetalertsapi.model.dto.*;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tomcat.util.digester.SystemPropertySource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.safetynet.safetynetalertsapi.exceptions.StationNotFoundException;
 import com.safetynet.safetynetalertsapi.model.FireStation;
 import com.safetynet.safetynetalertsapi.model.Person;
-import com.safetynet.safetynetalertsapi.model.dto.CoveredPersonDTO;
-import com.safetynet.safetynetalertsapi.model.dto.AlertPersonInfoDTO;
-import com.safetynet.safetynetalertsapi.model.dto.FireAlertDTO;
-import com.safetynet.safetynetalertsapi.model.dto.FireStationCoverageDTO;
-import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 import com.safetynet.safetynetalertsapi.repositories.JsonDataHandler;
 import com.safetynet.safetynetalertsapi.services.collectionutils.PersonFilterService;
 import com.safetynet.safetynetalertsapi.services.mappers.FireStationMapper;
 import com.safetynet.safetynetalertsapi.services.validators.FireStationValidator;
+
+import static java.util.stream.Collectors.toList;
 
 @Service
 public class FireStationFinder {
@@ -131,7 +131,23 @@ public class FireStationFinder {
 		return coveredPhones;
 	}
 
-	public FireAlertDTO getAllResidentsByAddress(String address) {
+	/**
+	 *Retrieves the fire station number and the list of people to alert for a given address.
+	 * <p>
+	 * This method:
+	 * <ul>
+	 *     <li>finds all persons living at the specified address,</li>
+	 *     <li>identifies the fire station number serving that address, </li>
+	 *     <li>and returns both as a {@link FireAlertDTO}.</li>
+	 * </ul>
+	 * The returned
+	 * list of residents includes their name, phone number, age, medications, and allergies.
+	 *
+	 * @param address an address where a fire alert is triggered
+	 * @return a {@link FireAlertDTO} containing the station number and a list of residents
+	 * with their personal and medical information
+	 */
+	public FireAlertDTO getFireAlertInfoByAddress(String address) {
 		List<Person> persons = personFinder.findAllPersonsByAddress(address);
 		
 		int stationNumber = getAllFireStations()
@@ -145,4 +161,42 @@ public class FireStationFinder {
 		
 		return new FireAlertDTO(stationNumber, residents);
 	}
+
+	/**
+	 * Returns a list of households served by the specified fire stations,
+	 * grouped by address.
+	 * <p>Each household includes the list of residents living
+	 * at that address, along with their name, phone number, age, and medical
+	 * information (medications, dosage, and allergies).</p>
+	 *
+	 * @param stationNumbers a list of fire station numbers for which to retrieve flood alert information
+	 * @return a {@link List} containing a list of {@link FloodAlertDTO},
+	 *         each representing an address and its residents to alert in case of flood
+	 */
+	//https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html
+	//https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#flatMap-java.util.function.Function-
+	//https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#map-java.util.function.Function-
+	public List<FloodAlertDTO> getFloodAlertInfoByStations(List<Integer> stationNumbers) {
+		// instancier le dto
+		List<FloodAlertDTO> floodAlertDTOList = new ArrayList<>();
+
+		// récupérer les adresses couvertes par les différentes casernes
+		stationNumbers.forEach(stationNumber -> {
+			List<String> coveredAddresses = getFireStationAddressesCoverage(stationNumber)
+					.stream()
+					.toList();
+
+			//créer un floodAlertDTO pour chaque adresse et ajouter les AlertPersonInfoDTO des résidents pour chaque adresse
+			for (String address : coveredAddresses) {
+				//FireAlertDTO contient des AlertPersonInfoDTO que je peux récupérer à partir des adresses
+				FireAlertDTO alertDTO = getFireAlertInfoByAddress(address.replace(" ", "").toLowerCase());
+				List<AlertPersonInfoDTO> persons = alertDTO.getResidents();
+
+				FloodAlertDTO floodAlertDTO = new FloodAlertDTO(address, persons);
+				//ajouter à la liste chaque FloodAlertDTO
+				floodAlertDTOList.add(floodAlertDTO);
+			}
+		});
+        return floodAlertDTOList;
+    }
 }


### PR DESCRIPTION
Création d'une méthode getFloodAlertInfoByStations() dans le contrôleur. 

Dans le service FireStationFinder, création d'une méthode qui prend en paramètre les numéros de casernes passés en paramètre de la requête.
Cette méthode : 
 - itère sur ces numéros de caserne,
 - retourne pour chacun toutes les adresses couverts par la caserne,
 - itère sur chaque adresse,
 - appelle la méthode existante getFireAlertInfoByAddress() qui retourne un FireAlertDTO contenant une Collection de AlertPersonInfoDTO, qui ont la structure attendue pour cette requête,
 - crée une instance de FloodAlertDTO pour chaque adresse, comprenant les propriétés : address (l'adresse concernée), et persons(une Collection de AlertPersonInfoDTO) récupérée depuis le FireAlertDTO créé précédemment. 
Enfin, elle retourne au contrôleur le FloodAlertDTO. 