### PR TITLE
requêtes POST : ajout du endpoint /firestation 

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
@@ -65,4 +65,20 @@ public class FireStationController {
 		List<FloodAlertDTO> personsToAlert = finder.getFloodAlertInfoByStations(stationNumbers);
 		return ResponseEntity.ok(personsToAlert);
 	}
+
+	/**
+	 * Create - Add a new {@link FireStation} to the data source file.
+	 *
+	 * @param fireStationDTO an object {@link FireStationDTO} representing a {@link FireStation}
+	 * @return The fire station object saved
+	 */
+	@PostMapping("/firestation")
+	public ResponseEntity<FireStationDTO> createFireStation(@RequestBody FireStationDTO fireStationDTO) {
+		try {
+			FireStationDTO savedFireStation = persister.saveFireStation(fireStationDTO);
+			return ResponseEntity.ok(savedFireStation);
+		} catch(ResourceAlreadyExistsException e) {
+			return ResponseEntity.status(HttpStatus.CONFLICT).build();
+		}
+    }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/exceptions/PersonAlreadyExistsException.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/exceptions/PersonAlreadyExistsException.java
@@ -1,7 +1,0 @@
-package com.safetynet.safetynetalertsapi.exceptions;
-
-public class PersonAlreadyExistsException extends Throwable {
-    public PersonAlreadyExistsException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/com/safetynet/safetynetalertsapi/exceptions/ResourceAlreadyExistsException.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/exceptions/ResourceAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.safetynet.safetynetalertsapi.exceptions;
+
+public class ResourceAlreadyExistsException extends Throwable {
+    public ResourceAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/FireStation.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/FireStation.java
@@ -1,6 +1,9 @@
 package com.safetynet.safetynetalertsapi.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
+
+import java.util.Objects;
 
 /**
  * Represents a fire station in the SafetyNet Alerts system.
@@ -19,6 +22,13 @@ public class FireStation {
 	
 	@JsonProperty("station")
 	private int station;
+
+	public FireStation() {}
+
+	public FireStation(@JsonProperty("address") String address, @JsonProperty("station") int station) {
+		this.address = address;
+		this.station = station;
+	}
 	
 	public int getStation() {
 		return station;
@@ -39,5 +49,19 @@ public class FireStation {
 	@Override
 	public String toString() {
 		return "station: " + this.station + "\n address: " + this.address;  
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object ) return true;
+		if (object == null || this.getClass() != object.getClass()) return false;
+		FireStation fireStation = (FireStation) object;
+		return Objects.equals(address, ((FireStation) object).getAddress()) &&
+				Objects.equals(station, ((FireStation) object).getStation());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(address, station);
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationDTO.java
@@ -1,9 +1,13 @@
 package com.safetynet.safetynetalertsapi.model.dto;
 
+import java.util.Objects;
+
 public class FireStationDTO {
 	private String address;
 	
 	private int station;
+
+	public FireStationDTO() {}
 	
 	public FireStationDTO(String address, int station) {
 		this.address = address;
@@ -29,5 +33,19 @@ public class FireStationDTO {
 	@Override
 	public String toString() {
 		return this.station + this.address;  
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object ) return true;
+		if (object == null || this.getClass() != object.getClass()) return false;
+		FireStationDTO fireStation = (FireStationDTO) object;
+		return Objects.equals(address, ((FireStationDTO) object).getAddress()) &&
+				Objects.equals(station, ((FireStationDTO) object).getStation());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(address, station);
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/FireStationRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/FireStationRepository.java
@@ -1,0 +1,38 @@
+package com.safetynet.safetynetalertsapi.repositories;
+
+import com.safetynet.safetynetalertsapi.exceptions.ResourceAlreadyExistsException;
+import com.safetynet.safetynetalertsapi.model.FireStation;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+import java.util.List;
+
+@Repository
+public class FireStationRepository {
+    public final Logger logger = LogManager.getLogger(FireStationRepository.class);
+
+    @Autowired
+    JsonDataHandler dataHandler;
+
+    public FireStation save(FireStation fireStation) throws ResourceAlreadyExistsException, IOException {
+        List<FireStation> fireStations = dataHandler.findAllFireStations();
+
+        System.out.println("fire station to string : "+fireStation.toString());
+
+        if (fireStations.stream().anyMatch(fs -> {
+            boolean match = fs.equals(fireStation);
+            System.out.println("Comparing: " + fs + " with " + fireStation + " => " + match);
+
+            return match;
+        }))
+        {
+            throw new ResourceAlreadyExistsException(fireStation.toString() + " is already in the database");
+        }
+        dataHandler.write(fireStation);
+
+        return fireStation;
+    }
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
@@ -33,24 +33,18 @@ public class JsonDataHandler implements DataHandler {
 	}
 	
 	public List<Person> findAllPersons() {
-		DataSet data = getAllData();
-		List<Person> persons = data.getPersons();
-		return persons;
+		return getAllData().getPersons();
 	}
 	
 	public List<FireStation> findAllFireStations() {
-		DataSet data = getAllData();
-		List<FireStation> fireStations = data.getFireStations();
-		return fireStations;
+		return getAllData().getFireStations();
 	}
 	
 	public List<MedicalRecord> findAllMedicalRecords() {
-		DataSet data = getAllData();
-		List<MedicalRecord> medicalRecords = data.getMedicalRecords();
-		return medicalRecords;
+		return getAllData().getMedicalRecords();
 	}
 
-	public void write(Person person) throws IOException {
+	public void write(Object resource) throws IOException {
 		//			//Java 8 date/time type `java.time.LocalDate` not supported by default
 		//https://www.javacodegeeks.com/jackson-java-8-date-time-localdate-support-issues.html
 		//configure ObjectMapper
@@ -61,15 +55,24 @@ public class JsonDataHandler implements DataHandler {
 		try {
 			//représenter la structure complète du fichier
 			DataSet existingData = mapper.readValue(file, DataSet.class);
-
 			//ajouter les données
-			existingData.getPersons().add(person);
+			if (resource instanceof Person) {
+				existingData.getPersons().add((Person) resource);
+			}
+
+			if (resource instanceof FireStation) {
+				existingData.getFireStations().add((FireStation) resource);
+			}
+
+			if (resource instanceof MedicalRecord) {
+				existingData.getMedicalRecords().add((MedicalRecord) resource);
+			}
 			// réécrire tte la structure mise à jour
 			mapper.writeValue(file, existingData);  //
 
 		} catch (
 				IOException e) {
-			logger.error(e.getMessage());
+			logger.error("Failed to write object of type {}: {}", resource.getClass().getSimpleName(), e.getMessage());
 		}
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/FireStationMapper.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/FireStationMapper.java
@@ -61,4 +61,8 @@ public class FireStationMapper {
 		
 		return residents;
 	}
+
+	public FireStation fromFireStationDtoToFireStation(FireStationDTO dto) {
+		return new FireStation(dto.getAddress(), dto.getStation());
+	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/FireStationPersister.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/FireStationPersister.java
@@ -1,0 +1,41 @@
+package com.safetynet.safetynetalertsapi.services.persisters;
+
+import com.safetynet.safetynetalertsapi.exceptions.ResourceAlreadyExistsException;
+import com.safetynet.safetynetalertsapi.model.FireStation;
+import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
+import com.safetynet.safetynetalertsapi.repositories.FireStationRepository;
+import com.safetynet.safetynetalertsapi.services.mappers.FireStationMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+public class FireStationPersister {
+
+    private final Logger logger = LogManager.getLogger(FireStationPersister.class);
+
+    @Autowired
+    FireStationRepository repository;
+
+    @Autowired
+    FireStationMapper mapper;
+
+
+    public FireStationDTO saveFireStation(FireStationDTO fireStationDTO) throws ResourceAlreadyExistsException {
+        FireStation fireStation = mapper.fromFireStationDtoToFireStation(fireStationDTO);
+        try {
+            FireStation savedFireStation = repository.save(fireStation);
+
+            FireStationDTO responseDtoFireStation =  mapper.fromFireStationToFireStationDTO(savedFireStation);
+
+            return responseDtoFireStation;
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+
+            throw new RuntimeException();
+        }
+    }
+}


### PR DESCRIPTION
- _Ajout de la méthode save(FireStation fireStation) dans FireStationRepository_  
Cette méthode vérifie d'abord si la station de pompiers (FireStation) fournie existe déjà dans la base de données, en fonction de l'adresse et du numéro de station. 
Si elle existe, une exception ResourceAlreadyExistsException est levée.
Si la station n'existe pas, elle est ajoutée à la base de données via la méthode write() du JsonDataHandler.

- _Modifications dans JsonDataHandler_ 
La méthode write() a été rendue générique et une logique a été ajoutée pour vérifier le type de ressource candidate à l'insertion, puis pour l'ajouter à la bonne section du fichier JSON.

**Gestion des exceptions** 
Si une erreur survient lors de l'écriture des données, une exception IOException est lancée par JsonDataHandler.

- _Dans FireStationRepository_, 
le contrôle de la duplication de la ressource est effectué avant l'ajout de la station. Si nécessaire, des exceptions ResourceAlreadyExistsException ou IOException sont levées.

- _Dans FireStationPersister_, 
toute exception IOException est capturée et enveloppée dans une RuntimeException. Les exceptions ResourceAlreadyExistsException sont lancées dans la signature de la méthode.

- _Dans FireStationController_ 
Le contrôleur capture l'exception ResourceAlreadyExistsException et retourne un statut HTTP 409 (Conflit) avec un corps nul si une station déjà existante est tentée d'être ajoutée. Sinon, un FireStationDTO est retourné