### PR TITLE
requêtes PUT : ajout d'un endpoint /medicalrecord

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/MedicalRecordController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/MedicalRecordController.java
@@ -1,5 +1,6 @@
 package com.safetynet.safetynetalertsapi.controllers;
 
+import com.safetynet.safetynetalertsapi.exceptions.NoChangesDetectedException;
 import com.safetynet.safetynetalertsapi.exceptions.ResourceAlreadyExistsException;
 import com.safetynet.safetynetalertsapi.exceptions.ResourceNotFoundException;
 import com.safetynet.safetynetalertsapi.model.MedicalRecord;
@@ -10,9 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 public class MedicalRecordController {
@@ -38,4 +37,18 @@ public class MedicalRecordController {
         }
     }
 
+    @PutMapping("/medicalrecord/{identity}")
+    public ResponseEntity<MedicalRecordDTO> updateMedicalRecord(@PathVariable String identity, @RequestBody MedicalRecordDTO medicalRecordDTO) {
+        logger.debug("Attempting to update the medical record of {}", medicalRecordDTO.getIdentity());
+        try {
+            persister.updateMedicalRecord(medicalRecordDTO);
+            return ResponseEntity.ok(medicalRecordDTO);
+        } catch (ResourceNotFoundException e) {
+            logger.error(e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (NoChangesDetectedException e) {
+            logger.info(e.getMessage());
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+    }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/exceptions/NoChangesDetectedException.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/exceptions/NoChangesDetectedException.java
@@ -1,0 +1,7 @@
+package com.safetynet.safetynetalertsapi.exceptions;
+
+public class NoChangesDetectedException extends Throwable {
+    public NoChangesDetectedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/DataSet.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/DataSet.java
@@ -34,7 +34,7 @@ public class DataSet {
 		return medicalRecords;
 	}
 
-	public void setMedicalrecords(List<MedicalRecord> medicalRecords) {
+	public void setMedicalRecords(List<MedicalRecord> medicalRecords) {
 		this.medicalRecords = medicalRecords;
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
@@ -27,9 +27,7 @@ public class JsonDataHandler implements DataHandler {
     //			//Java 8 date/time type `java.time.LocalDate` not supported by default
     //https://www.javacodegeeks.com/jackson-java-8-date-time-localdate-support-issues.html
     //configure ObjectMapper
-    private static final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .enable(SerializationFeature.INDENT_OUTPUT);
+    private static final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).enable(SerializationFeature.INDENT_OUTPUT);
 
     @Autowired
     private DataSetLoader dataSetLoader;
@@ -74,8 +72,7 @@ public class JsonDataHandler implements DataHandler {
             // réécrire tte la structure mise à jour
             mapper.writeValue(file, existingData);  //
 
-        } catch (
-                IOException e) {
+        } catch (IOException e) {
             logger.error("Failed to write object of type {}: {}", resource.getClass().getSimpleName(), e.getMessage());
         }
     }
@@ -116,6 +113,21 @@ public class JsonDataHandler implements DataHandler {
                 }
                 existingData.setFireStations(fireStations);
             }
+
+            if (resource instanceof MedicalRecord newMedicalRecord) {
+                List<MedicalRecord> medicalRecords = existingData.getMedicalRecords();
+
+                for (int i = 0; i < medicalRecords.size(); i++) {
+                    MedicalRecord existingMedicalRecord = medicalRecords.get(i);
+
+                    if (newMedicalRecord.getIdentity().equals(existingMedicalRecord.getIdentity())) {
+                        medicalRecords.set(i, newMedicalRecord);
+                        break;
+                    }
+                }
+                existingData.setMedicalRecords(medicalRecords);
+            }
+
             mapper.writeValue(file, existingData);
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
@@ -1,6 +1,8 @@
 package com.safetynet.safetynetalertsapi.repositories;
 
+import com.safetynet.safetynetalertsapi.exceptions.NoChangesDetectedException;
 import com.safetynet.safetynetalertsapi.exceptions.ResourceAlreadyExistsException;
+import com.safetynet.safetynetalertsapi.exceptions.ResourceNotFoundException;
 import com.safetynet.safetynetalertsapi.model.MedicalRecord;
 import com.safetynet.safetynetalertsapi.utils.StringFormatter;
 import org.apache.logging.log4j.LogManager;
@@ -25,7 +27,7 @@ public class MedicalRecordRepository {
         List<MedicalRecord> medicalRecords = dataHandler.findAllMedicalRecords();
 
         if (medicalRecords.stream().anyMatch(record -> formatter.normalizeString(record.getIdentity().toString()).equals(formatter.normalizeString(medicalRecord.getIdentity().toString())))) {
-            throw new ResourceAlreadyExistsException("A medical record exists already for " + medicalRecord.getIdentity());
+            throw new ResourceAlreadyExistsException(String.format("A medical record exists already for %s", medicalRecord.getIdentity()));
         }
 
         dataHandler.write(medicalRecord);
@@ -33,4 +35,24 @@ public class MedicalRecordRepository {
         return medicalRecord;
     }
 
+    public MedicalRecord update(MedicalRecord medicalRecord) throws ResourceNotFoundException, NoChangesDetectedException {
+        List<MedicalRecord> medicalRecords = dataHandler.findAllMedicalRecords();
+
+        if (medicalRecords.stream().noneMatch(record -> formatter.normalizeString(record.getIdentity().toString()).equals(formatter.normalizeString(medicalRecord.getIdentity().toString())))) {
+            throw new ResourceNotFoundException(String.format("No medical record exists for %s", medicalRecord.getIdentity()));
+        }
+
+        if (medicalRecords.stream().anyMatch(record ->
+                record.getIdentity().equals(medicalRecord.getIdentity()) &&
+                        record.getBirthDate().equals(medicalRecord.getBirthDate()) &&
+                        record.getAllergies().equals(medicalRecord.getAllergies()) &&
+                        record.getMedications().equals(medicalRecord.getMedications())
+        )) {
+            throw new NoChangesDetectedException("The medical record data is identical to the existing record. No changes are required");
+        }
+
+        dataHandler.update(medicalRecord);
+
+        return medicalRecord;
+    }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/MedicalRecordPersister.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/MedicalRecordPersister.java
@@ -1,6 +1,8 @@
 package com.safetynet.safetynetalertsapi.services.persisters;
 
+import com.safetynet.safetynetalertsapi.exceptions.NoChangesDetectedException;
 import com.safetynet.safetynetalertsapi.exceptions.ResourceAlreadyExistsException;
+import com.safetynet.safetynetalertsapi.exceptions.ResourceNotFoundException;
 import com.safetynet.safetynetalertsapi.model.MedicalRecord;
 import com.safetynet.safetynetalertsapi.model.dto.MedicalRecordDTO;
 import com.safetynet.safetynetalertsapi.repositories.MedicalRecordRepository;
@@ -16,11 +18,28 @@ public class MedicalRecordPersister {
     @Autowired
     MedicalRecordMapper mapper;
 
+    /**
+     * @param medicalRecordDTO representing the {@link MedicalRecord} structure
+     * @return savedMedicalRecord the saved {@link MedicalRecordDTO}
+     * @throws ResourceAlreadyExistsException
+     */
     public MedicalRecordDTO createMedicalRecord(MedicalRecordDTO medicalRecordDTO) throws ResourceAlreadyExistsException {
         MedicalRecord medicalRecord = mapper.fromMedicalRecordDtoToMedicalRecord(medicalRecordDTO);
 
         MedicalRecord savedMedicalRecord = repository.save(medicalRecord);
 
         return mapper.fromMedicalRecordToMedicalRecordDto(savedMedicalRecord);
+    }
+
+    /**
+     * @param medicalRecordDTO representing the {@link MedicalRecord} structure
+     * @return updatedMedicalRecord the updated {@link MedicalRecordDTO}
+     */
+    public MedicalRecordDTO updateMedicalRecord(MedicalRecordDTO medicalRecordDTO) throws ResourceNotFoundException, NoChangesDetectedException {
+        MedicalRecord medicalRecord = mapper.fromMedicalRecordDtoToMedicalRecord(medicalRecordDTO);
+
+        MedicalRecord updatedMedicalRecord = repository.update(medicalRecord);
+
+        return mapper.fromMedicalRecordToMedicalRecordDto(updatedMedicalRecord);
     }
 }


### PR DESCRIPTION
## Model
Création d'une exception personnalisée NoChangesDetectedException pour signaler qu'aucun changement n'a été effectué sur un dossier médical.

## MedicalRecordController 
Ajout de la méthode updateMedicalRecord() avec l'annotation PutMapping, qui accepte un MedicalRecordDto dans le body de la requête et une path variable String identity.
Cette méthode : 
- appelle la méthode updateMedicalRecord() du MedicalRecordPersister,
- retourne une ResponseEntity avec :
  - statut 404 si aucun dossier médical correspondant n'est trouvé.
  - statut 204 (no content) si aucune modification n'a été détectée.

## MedicalRecordPersister
Ajout de la méthode updateMedicalRecord(), qui :
- effectue le mapping du DTO vers un objet MedicalRecord et inversement,
- appelle la méthode update() du MedicalRecordRepository.
- retourne le record sauvegardé ou propage une ResourceNotFoundException ou une NoChangesDetectedException si nécessaire.

## MedicalRecordRepository
Ajout de la méthode update() qui :
- récupère la liste des dossiers médicaux depuis la source de données.
- lance une ResourceNotFoundException si aucun dossier médical correspondant n'est trouvé.
- lance une NoChangesDetectedException si les données du dossier médical sont identiques à celles déjà enregistrées.
- appelle la méthode update() du JsonDataHandler pour mettre à jour les données.
- retourne le MedicalRecord au MedicalRecordPersister.