### PR TITLE
requêtes PUT : ajout d'un endpoint /medicalrecord

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/MedicalRecordController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/MedicalRecordController.java
@@ -21,8 +21,9 @@ public class MedicalRecordController {
     MedicalRecordPersister persister;
 
     /**
-     * Create - Add a new {@link MedicalRecordDTO}
-     * @param medicalRecordDTO An object {@link MedicalRecord}
+     * Creates a {@link MedicalRecord} for a person identified by their last name and first name.
+     *
+     * @param medicalRecordDTO representing the data structure of a {@link MedicalRecord}
      * @return The person object saved
      */
     @PostMapping("/medicalrecord")
@@ -37,11 +38,19 @@ public class MedicalRecordController {
         }
     }
 
-    @PutMapping("/medicalrecord/{identity}")
-    public ResponseEntity<MedicalRecordDTO> updateMedicalRecord(@PathVariable String identity, @RequestBody MedicalRecordDTO medicalRecordDTO) {
+    /**
+     * Updates the medical record for a person identified by their last name and first name.
+     *
+     * @param lastName the lastname of the person
+     * @param medicalRecordDTO representing the data structure of a {@link MedicalRecord}
+     * @return a {@link ResponseEntity} containing a JSON representation of the updated medical record
+     */
+    @PutMapping("/medicalrecord/{lastName}/{firstName}")
+    public ResponseEntity<MedicalRecordDTO> updateMedicalRecord(@PathVariable String lastName, @PathVariable String firstName, @RequestBody MedicalRecordDTO medicalRecordDTO) {
         logger.debug("Attempting to update the medical record of {}", medicalRecordDTO.getIdentity());
         try {
             persister.updateMedicalRecord(medicalRecordDTO);
+            logger.info("The medical record of {} {} has been updated.", lastName, firstName);
             return ResponseEntity.ok(medicalRecordDTO);
         } catch (ResourceNotFoundException e) {
             logger.error(e.getMessage());
@@ -49,6 +58,29 @@ public class MedicalRecordController {
         } catch (NoChangesDetectedException e) {
             logger.info(e.getMessage());
             return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        }
+    }
+
+    /**
+     * Deletes the {@link MedicalRecord} for a person identified by their last name and first name.
+     *
+     * @param lastName the last name of the person related to the medical record
+     * @param firstName the first name of the person related to the medical record
+     * @return a {@link ResponseEntity} indicating the result of the deletion attempt:
+     *  - HTTP status 204 No Content if the record is successfully deleted,
+     *  - HTTP status 404 if the record does not exist.
+     */
+    @DeleteMapping("/medicalrecord/{lastName}/{firstName}")
+    public ResponseEntity<Void> deleteMedicalRecord(@PathVariable String lastName, @PathVariable String firstName) {
+        String fullName = lastName + " " + firstName;
+        logger.debug("Attempting to delete medical record of {} {}.", lastName, firstName);
+        try {
+           persister.deleteMedicalRecord(lastName, firstName);
+           logger.info("The medical record of {} {} has been removed.", lastName, firstName);
+           return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } catch(ResourceNotFoundException e) {
+            logger.error(e.getMessage());
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
@@ -169,6 +169,20 @@ public class JsonDataHandler implements DataHandler {
                 existingData.setFireStations(fireStations);
             }
 
+            if (type.equals(MedicalRecord.class)) {
+                List<MedicalRecord> medicalRecords = existingData.getMedicalRecords();
+
+                for (int i = 0; i < medicalRecords.size(); i++) {
+                    MedicalRecord medicalRecordToDelete = medicalRecords.get(i);
+
+                    if (formatter.normalizeString(uniqueIdentifier).equals(formatter.normalizeString(medicalRecordToDelete.getIdentity().toString()))) {
+                        medicalRecords.remove(medicalRecordToDelete);
+                        break;
+                    }
+                }
+                existingData.setMedicalRecords(medicalRecords);
+            }
+
             mapper.writeValue(file, existingData);
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
@@ -38,7 +38,7 @@ public class MedicalRecordRepository {
     public MedicalRecord update(MedicalRecord medicalRecord) throws ResourceNotFoundException, NoChangesDetectedException {
         List<MedicalRecord> medicalRecords = dataHandler.findAllMedicalRecords();
 
-        if (medicalRecords.stream().noneMatch(record -> formatter.normalizeString(record.getIdentity().toString()).equals(formatter.normalizeString(medicalRecord.getIdentity().toString())))) {
+        if (medicalRecords.stream().noneMatch(record -> record.getIdentity().toString().equalsIgnoreCase(medicalRecord.getIdentity().toString()))) {
             throw new ResourceNotFoundException(String.format("No medical record exists for %s", medicalRecord.getIdentity()));
         }
 
@@ -54,5 +54,16 @@ public class MedicalRecordRepository {
         dataHandler.update(medicalRecord);
 
         return medicalRecord;
+    }
+
+    public void delete(String lastName, String firstName) throws ResourceNotFoundException {
+        List<MedicalRecord> medicalRecords = dataHandler.findAllMedicalRecords();
+        String uniqueIdentifier = lastName.concat(firstName);
+
+        if (medicalRecords.stream().noneMatch(record -> formatter.normalizeString(record.getIdentity().toString()).equals(uniqueIdentifier))) {
+            throw new ResourceNotFoundException("No medical record exists for this identifier");
+        }
+
+        dataHandler.delete(MedicalRecord.class, uniqueIdentifier);
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/MedicalRecordPersister.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/MedicalRecordPersister.java
@@ -42,4 +42,8 @@ public class MedicalRecordPersister {
 
         return mapper.fromMedicalRecordToMedicalRecordDto(updatedMedicalRecord);
     }
+
+    public void deleteMedicalRecord(String lastName, String firstName) throws ResourceNotFoundException {
+        repository.delete(lastName, firstName);
+    }
 }


### PR DESCRIPTION
Implémentation de la fonctionnalité de suppression des dossiers médicaux, avec une gestion des erreurs NotFound.

## MedicalRecordController

Ajout de la méthode `deleteMedicalRecord()` qui :
- appelle la méthode `deleteMedicalRecord()` du `MedicalRecordPersister`,
- Retourne une `ResponseEntity` sans body (statut 204 ou 404).
---

## MedicalRecordRepository

Création de la méthode `delete(String lastName, String firstName)` qui appelle la méthode `delete(Class<T>, String uniqueIdentifier)` du `JsonDataHandler`. 
L'argument uniqueIdentifier est composé de la concaténation des arguments `firstName` et `lastName`.

---

## MedicalRecordPersister

Ajout de la méthode `deleteMedicalRecord()` qui appelle la méthode `delete()` du repository.

---

## JsonDataHandler

Ajout de la condition nécessaire à traiter les dossiers médicaux dans la méthode `delete()`.
Lorsque le dossier correspondant est trouvé : 
 - suppression du dossier dans la liste des dossiers médicaux, 
 - mise à jour du jeu de données, 
 - et réécriture du fichier source.

