### PR TITLE
Feat/repository structure

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/FireStationController.java
@@ -27,7 +27,7 @@ import com.safetynet.safetynetalertsapi.model.dto.FloodAlertDTO;
 @RestController
 public class FireStationController {
 
-    private Logger logger = LogManager.getLogger(FireStationController.class);
+    private final Logger logger = LogManager.getLogger(FireStationController.class);
 
     @Autowired
     private FireStationFinder finder;
@@ -97,12 +97,11 @@ public class FireStationController {
     /**
      * Update - Update a {@link FireStation}
      *
-     * @param address       - The address associated to the station
-     * @param stationNumber - The station number associated to the given
+     * @param address - The address associated to a station
      * @return a {@link FireStationDTO}
      */
-    @PutMapping("/firestation/{stationNumber}/{address}")
-    public ResponseEntity<FireStationDTO> updateFireStation(@PathVariable String stationNumber, @PathVariable String address, @RequestBody FireStationDTO fireStationDTO) {
+    @PutMapping("/firestation/{address}")
+    public ResponseEntity<FireStationDTO> updateFireStation(@PathVariable String address, @RequestBody FireStationDTO fireStationDTO) {
         try {
             FireStationDTO updatedFireStation = persister.updateFireStation(fireStationDTO, address);
             return ResponseEntity.ok(updatedFireStation);
@@ -124,8 +123,7 @@ public class FireStationController {
     @DeleteMapping("/firestation/{stationNumber}/{address}")
     public HttpEntity<?> deleteFireStation(@PathVariable String address, @PathVariable String stationNumber) {
         try {
-            String identifier = formatter.normalizeString(address + stationNumber);
-            persister.deleteFireStation(identifier);
+            persister.deleteFireStation(address, stationNumber);
             logger.info("The relation between the firestation {} and the address {} has been removed", stationNumber, address);
             return ResponseEntity.noContent().build();
         } catch (ResourceNotFoundException e) {

--- a/src/main/java/com/safetynet/safetynetalertsapi/controllers/PersonController.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/controllers/PersonController.java
@@ -107,18 +107,17 @@ public class PersonController {
 		}
 	}
 
-	@DeleteMapping("/person/{identity}")
-	public HttpEntity<?> deletePerson(@PathVariable String identity) {
+	@DeleteMapping("/person/{lastName}/{firstName}")
+	public HttpEntity<?> deletePerson(@PathVariable String lastName, @PathVariable String firstName) {
+		String fullName = lastName + " " + firstName;
+		logger.debug("Attempting to delete {} {} from the database.", lastName, firstName);
 		try {
-			persister.deletePerson(identity);
-			logger.info("Person named {} has been successfully deleted", identity);
+			persister.deletePerson(lastName, firstName);
+			logger.info("Person named {} {} has been successfully deleted", firstName, lastName);
 			return ResponseEntity.noContent().build();
 		} catch(ResourceNotFoundException e) {
 			logger.error(e.getMessage());
 			return ResponseEntity.status(404).build();
-		} catch (RuntimeException e) {
-            logger.error("An error occurred while deleting the resource");
-			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Internal error");
-        }
+		}
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Address.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Address.java
@@ -1,6 +1,6 @@
 package com.safetynet.safetynetalertsapi.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Objects;
 
 public class Address {
 	private String address;
@@ -43,5 +43,15 @@ public class Address {
 	
 	public String toString() {
 		return this.address + " " + this.city + " " + this.zip;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Address address1 = (Address) o;
+		return Objects.equals(address, address1.address) &&
+				Objects.equals(city, address1.city) &&
+				Objects.equals(zip, address1.zip);
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/MedicalRecord.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/MedicalRecord.java
@@ -2,6 +2,7 @@ package com.safetynet.safetynetalertsapi.model;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -74,5 +75,22 @@ public class MedicalRecord implements Identifiable {
     @Override
     public String toString() {
         return this.identity.toString() + this.birthDate + this.allergies + this.medications;
+    }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        //Objects.equals() pour effectuer une comparaison valeur par valeur
+        MedicalRecord that = (MedicalRecord) o;
+        return Objects.equals(identity, that.identity)
+                && Objects.equals(birthDate, that.birthDate)
+                && Objects.equals(allergies, that.allergies)
+                && Objects.equals(medications, that.medications);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(identity, birthDate, allergies, medications);
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Person.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Person.java
@@ -4,6 +4,8 @@ package com.safetynet.safetynetalertsapi.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
+import java.util.Objects;
+
 /**
  * This class represents a person in the SafetyNet Alerts system.
  * It contains the personal information of individuals.
@@ -66,7 +68,26 @@ public class Person implements Identifiable {
 	public void setEmail(String email) {
 		this.email = email;
 	}
-	
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		Person person = (Person) o;
+
+		return (Objects.equals(identity, person.identity) &&
+				Objects.equals(address, person.address) &&
+				Objects.equals(phone, person.phone) &&
+				Objects.equals(email, person.email)
+		);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(identity);
+	}
+
 	@Override
 	public String toString() {
 		return this.identity

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/BaseRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/BaseRepository.java
@@ -1,0 +1,12 @@
+package com.safetynet.safetynetalertsapi.repositories;
+
+import com.safetynet.safetynetalertsapi.exceptions.ResourceAlreadyExistsException;
+import com.safetynet.safetynetalertsapi.exceptions.ResourceNotFoundException;
+
+public interface BaseRepository<T> {
+    T save(T resource) throws ResourceAlreadyExistsException;
+
+    void delete(String param1, String param2) throws ResourceNotFoundException;
+
+    T update(T resource) throws ResourceNotFoundException;
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/FireStationRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/FireStationRepository.java
@@ -41,12 +41,14 @@ public class FireStationRepository {
     public void delete(String identifier) throws ResourceNotFoundException, RuntimeException {
         List<FireStation> fireStations = dataHandler.findAllFireStations();
 
-        if (fireStations.stream().noneMatch(fs -> {
-            return formatter.normalizeString(fs.toString()).equals(identifier);
-        })) {
-            throw new ResourceNotFoundException("The station with the provided address and station number is not found.");
-        }
-        dataHandler.delete(FireStation.class, identifier);
+        //REFACTO : simplifier la vérification et passer directemet l'objet à supprimer
+        FireStation fireStationToDelete = fireStations
+                .stream()
+                .filter(fs -> formatter.normalizeString(fs.toString()).equals(identifier))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("The station with the provided address and station number is not found."));
+
+        dataHandler.delete(FireStation.class, fireStationToDelete);
     }
 
     public FireStation update(FireStation fireStation, String address) throws ResourceNotFoundException, InvalidAddressException {

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/FireStationRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/FireStationRepository.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.util.List;
 
 @Repository
-public class FireStationRepository {
+public class FireStationRepository implements BaseRepository<FireStation> {
     public final Logger logger = LogManager.getLogger(FireStationRepository.class);
 
     @Autowired
@@ -22,12 +22,11 @@ public class FireStationRepository {
     @Autowired
     StringFormatter formatter;
 
-    public FireStation save(FireStation fireStation) throws ResourceAlreadyExistsException, IOException {
+    public FireStation save(FireStation fireStation) throws ResourceAlreadyExistsException {
         List<FireStation> fireStations = dataHandler.findAllFireStations();
 
         if (fireStations.stream().anyMatch(fs -> {
             boolean match = fs.equals(fireStation);
-            System.out.println("Comparing: " + fs + " with " + fireStation + " => " + match);
 
             return match;
         })) {
@@ -38,10 +37,10 @@ public class FireStationRepository {
         return fireStation;
     }
 
-    public void delete(String identifier) throws ResourceNotFoundException, RuntimeException {
+    public void delete(String address, String stationNumber) throws ResourceNotFoundException {
         List<FireStation> fireStations = dataHandler.findAllFireStations();
+        String identifier = address.concat(stationNumber);
 
-        //REFACTO : simplifier la vérification et passer directemet l'objet à supprimer
         FireStation fireStationToDelete = fireStations
                 .stream()
                 .filter(fs -> formatter.normalizeString(fs.toString()).equals(identifier))
@@ -51,18 +50,15 @@ public class FireStationRepository {
         dataHandler.delete(FireStation.class, fireStationToDelete);
     }
 
-    public FireStation update(FireStation fireStation, String address) throws ResourceNotFoundException, InvalidAddressException {
-        if (!formatter.normalizeString(fireStation.getAddress()).equals(formatter.normalizeString(address))) {
-            throw new InvalidAddressException("The provided address in the request does not match the fire station address.");
-        }
 
+    public FireStation update(FireStation fireStation) throws ResourceNotFoundException {
         List<FireStation> fireStations = dataHandler.findAllFireStations();
 
-        if (fireStations.stream().noneMatch(fs -> {
-            return (formatter.normalizeString(fs.getAddress()).equals(formatter.normalizeString(address)));
-        })) {
-            throw new ResourceNotFoundException("No station exists for the provided address.");
-        }
+        fireStations
+                .stream()
+                .filter(fs -> fs.getAddress().equals(fireStation.getAddress()))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("No resource was found for the provided address"));
 
         dataHandler.update(fireStation);
 

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/JsonDataHandler.java
@@ -24,9 +24,6 @@ public class JsonDataHandler implements DataHandler {
 
     private final Logger logger = LogManager.getLogger(JsonDataHandler.class);
 
-    //			//Java 8 date/time type `java.time.LocalDate` not supported by default
-    //https://www.javacodegeeks.com/jackson-java-8-date-time-localdate-support-issues.html
-    //configure ObjectMapper
     private static final ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule()).disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS).enable(SerializationFeature.INDENT_OUTPUT);
 
     @Autowired
@@ -135,54 +132,27 @@ public class JsonDataHandler implements DataHandler {
         }
     }
 
-    public <T> void delete(Class<T> type, String uniqueIdentifier) {
+    public <T> void delete(T type, T entity) {
         try {
             DataSet existingData = mapper.readValue(file, DataSet.class);
 
             if (type.equals(Person.class)) {
                 List<Person> persons = existingData.getPersons();
-
-                //chercher la personne dans la liste
-                for (int i = 0; i < persons.size(); i++) {
-                    Person personToDelete = persons.get(i);
-
-                    //si la personne est trouvée, on la supprime
-                    if (formatter.normalizeString(uniqueIdentifier).equals(formatter.normalizeString(personToDelete.getIdentity().toString()))) {
-                        persons.remove(personToDelete);
-                        break;
-                    }
-                }
+                persons.remove((Person) entity);
                 existingData.setPersons(persons);
             }
 
             if (type.equals(FireStation.class)) {
                 List<FireStation> fireStations = existingData.getFireStations();
-
-                for (int i = 0; i < fireStations.size(); i++) {
-                    FireStation fireStationToDelete = fireStations.get(i);
-
-                    if (formatter.normalizeString(uniqueIdentifier).equals(formatter.normalizeString(fireStationToDelete.toString()))) {
-                        fireStations.remove(fireStationToDelete);
-                        break;
-                    }
-                }
+                fireStations.remove((FireStation) entity);
                 existingData.setFireStations(fireStations);
             }
 
             if (type.equals(MedicalRecord.class)) {
                 List<MedicalRecord> medicalRecords = existingData.getMedicalRecords();
-
-                for (int i = 0; i < medicalRecords.size(); i++) {
-                    MedicalRecord medicalRecordToDelete = medicalRecords.get(i);
-
-                    if (formatter.normalizeString(uniqueIdentifier).equals(formatter.normalizeString(medicalRecordToDelete.getIdentity().toString()))) {
-                        medicalRecords.remove(medicalRecordToDelete);
-                        break;
-                    }
-                }
+                medicalRecords.remove((MedicalRecord) entity);
                 existingData.setMedicalRecords(medicalRecords);
             }
-
             mapper.writeValue(file, existingData);
         } catch (IOException e) {
             logger.error(e.getMessage());

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class MedicalRecordRepository {
+public class MedicalRecordRepository implements BaseRepository<MedicalRecord> {
 
     private final Logger logger = LogManager.getLogger(MedicalRecordRepository.class);
 
@@ -35,20 +35,11 @@ public class MedicalRecordRepository {
         return medicalRecord;
     }
 
-    public MedicalRecord update(MedicalRecord medicalRecord) throws ResourceNotFoundException, NoChangesDetectedException {
+    public MedicalRecord update(MedicalRecord medicalRecord) throws ResourceNotFoundException {
         List<MedicalRecord> medicalRecords = dataHandler.findAllMedicalRecords();
 
         if (medicalRecords.stream().noneMatch(record -> record.getIdentity().toString().equalsIgnoreCase(medicalRecord.getIdentity().toString()))) {
             throw new ResourceNotFoundException(String.format("No medical record exists for %s", medicalRecord.getIdentity()));
-        }
-
-        if (medicalRecords.stream().anyMatch(record ->
-                record.getIdentity().equals(medicalRecord.getIdentity()) &&
-                        record.getBirthDate().equals(medicalRecord.getBirthDate()) &&
-                        record.getAllergies().equals(medicalRecord.getAllergies()) &&
-                        record.getMedications().equals(medicalRecord.getMedications())
-        )) {
-            throw new NoChangesDetectedException("The medical record data is identical to the existing record. No changes are required");
         }
 
         dataHandler.update(medicalRecord);

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/MedicalRecordRepository.java
@@ -58,12 +58,14 @@ public class MedicalRecordRepository {
 
     public void delete(String lastName, String firstName) throws ResourceNotFoundException {
         List<MedicalRecord> medicalRecords = dataHandler.findAllMedicalRecords();
-        String uniqueIdentifier = lastName.concat(firstName);
+        String uniqueIdentifier = firstName.concat(lastName);
 
-        if (medicalRecords.stream().noneMatch(record -> formatter.normalizeString(record.getIdentity().toString()).equals(uniqueIdentifier))) {
-            throw new ResourceNotFoundException("No medical record exists for this identifier");
-        }
+        MedicalRecord medicalRecordToDelete = medicalRecords
+                .stream()
+                .filter(record -> formatter.normalizeString(record.getIdentity().toString()).equals(uniqueIdentifier))
+                .findFirst()
+                .orElseThrow(() -> new ResourceNotFoundException("No medical record exists for this identifier"));
 
-        dataHandler.delete(MedicalRecord.class, uniqueIdentifier);
+        dataHandler.delete(MedicalRecord.class, medicalRecordToDelete);
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/repositories/PersonRepository.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/repositories/PersonRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public class PersonRepository {
+public class PersonRepository implements BaseRepository<Person> {
 
     public final Logger logger = LogManager.getLogger();
     @Autowired

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/FireStationPersister.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/FireStationPersister.java
@@ -7,6 +7,7 @@ import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 import com.safetynet.safetynetalertsapi.repositories.FireStationRepository;
 import com.safetynet.safetynetalertsapi.repositories.InvalidAddressException;
 import com.safetynet.safetynetalertsapi.services.mappers.FireStationMapper;
+import com.safetynet.safetynetalertsapi.services.validators.FireStationValidator;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,30 +26,28 @@ public class FireStationPersister {
     @Autowired
     FireStationMapper mapper;
 
+    @Autowired
+    FireStationValidator validator;
+
 
     public FireStationDTO saveFireStation(FireStationDTO fireStationDTO) throws ResourceAlreadyExistsException {
         FireStation fireStation = mapper.fromFireStationDtoToFireStation(fireStationDTO);
-        try {
-            FireStation savedFireStation = repository.save(fireStation);
+        FireStation savedFireStation = repository.save(fireStation);
+        FireStationDTO responseDtoFireStation = mapper.fromFireStationToFireStationDTO(savedFireStation);
 
-            FireStationDTO responseDtoFireStation = mapper.fromFireStationToFireStationDTO(savedFireStation);
-
-            return responseDtoFireStation;
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-
-            throw new RuntimeException();
-        }
+        return responseDtoFireStation;
     }
 
-    public void deleteFireStation(String identifier) throws ResourceNotFoundException, RuntimeException {
-        repository.delete(identifier);
+    public void deleteFireStation(String address, String stationNumber) throws ResourceNotFoundException, RuntimeException {
+        repository.delete(address, stationNumber);
     }
 
     public FireStationDTO updateFireStation(FireStationDTO fireStationDTO, String address) throws ResourceNotFoundException, InvalidAddressException {
         FireStation fireStation = mapper.fromFireStationDtoToFireStation(fireStationDTO);
 
-        FireStation updatedFireStation = repository.update(fireStation, address);
+        validator.validateFireStationAddressAssociation(fireStation, address);
+
+        FireStation updatedFireStation = repository.update(fireStation);
 
         FireStationDTO responseFireStation = mapper.fromFireStationToFireStationDTO(updatedFireStation);
 

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/PersonPersister.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/persisters/PersonPersister.java
@@ -37,7 +37,7 @@ public class PersonPersister {
             return responsePerson;
     }
 
-    public void deletePerson(String identity) throws ResourceNotFoundException, RuntimeException {
-        repository.delete(identity);
+    public void deletePerson(String lastName, String firstName) throws ResourceNotFoundException, RuntimeException {
+        repository.delete(lastName, firstName);
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/validators/FireStationValidator.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/validators/FireStationValidator.java
@@ -2,6 +2,8 @@ package com.safetynet.safetynetalertsapi.services.validators;
 
 import java.util.List;
 
+import com.safetynet.safetynetalertsapi.repositories.InvalidAddressException;
+import com.safetynet.safetynetalertsapi.utils.StringFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +15,9 @@ public class FireStationValidator {
 	
 	@Autowired
 	JsonDataHandler dataHandler;
+
+	@Autowired
+	StringFormatter formatter;
 	
 	public boolean stationExists(int stationNumber) {
 		List<FireStation> fireStations = dataHandler.getAllData().getFireStations();
@@ -21,5 +26,18 @@ public class FireStationValidator {
 		.anyMatch(station -> station.getStation() == stationNumber);
 		
 		return exists;
+	}
+
+	/**
+	 * Ensures the provided address from the URL matches the one in the FireStation object (from the request body).
+	 *
+	 * @param fireStation
+	 * @param address
+	 * @throws InvalidAddressException
+	 */
+	public void validateFireStationAddressAssociation(FireStation fireStation, String address) throws InvalidAddressException {
+		if (!formatter.normalizeString(address).equals(formatter.normalizeString(fireStation.getAddress()))) {
+			throw new InvalidAddressException("The provided address in the request URL does not match the provided fire station address.");
+		}
 	}
 }


### PR DESCRIPTION
# Modification de la structure de la couche d'accès aux données

## Modifications principales

- BaseRepository.java :
Création de l'interface générique BaseRepository définissant les méthodes save(), update(), et delete() pour les opérations CRUD.

 - MedicalRecordRepository.java, FireStationRepository.java, PersonRepository.java :
Implémentation de l'interface BaseRepository dans les repositories.

- Simplification de la logique de la méthode delete() dans chaque repository : appel de la méthode delete() de JsonDataHandler avec les arguments : type de classe, entité à supprimer.
Cette modification évite la redondance du filtrage dans le repository + recherche de l'entité à supprimer dans le JsonDataHandler.
Les Controllers et Persister services ont été mis à jour en conséquence. 

- Suppression de la logique métier de validation dans les repositories et délégation de la validation aux services de validation (validator).
 ---
Ces modifications permettent une séparation claire des responsabilités et une uniformisation des signatures de méthodes des différents repositories. 