### PR TITLE
feat: add HTTP request and transaction logging filters

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/config/filters/RequestResponseLoggingFilter.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/config/filters/RequestResponseLoggingFilter.java
@@ -1,0 +1,39 @@
+package com.safetynet.safetynetalertsapi.config.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Order(1)
+public class RequestResponseLoggingFilter extends HttpFilter {
+    private static final Logger logger = LogManager.getLogger(RequestResponseLoggingFilter.class);
+
+    @Override
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain) throws ServletException, IOException {
+
+        HttpServletRequest req = (HttpServletRequest) request;
+        HttpServletResponse res = (HttpServletResponse) response;
+
+        logger.info(
+                "Request {} {}, from {}", req.getMethod(), req.getRequestURI(), req.getRemoteAddr());
+        chain.doFilter(request, response);
+
+        logger.info(
+                "Response: {}",
+                res.getStatus());
+    }
+}

--- a/src/main/java/com/safetynet/safetynetalertsapi/config/filters/TransactionFilter.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/config/filters/TransactionFilter.java
@@ -1,0 +1,29 @@
+package com.safetynet.safetynetalertsapi.config.filters;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Order(2)
+public class TransactionFilter extends HttpFilter {
+
+    private static final Logger logger = LogManager.getLogger(TransactionFilter.class);
+
+    @Override
+    protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest req = (HttpServletRequest) request;
+        logger.debug("Starting a transaction for request : {}", req.getRequestURI());
+
+        chain.doFilter(request, response);
+        logger.debug("Committing a transaction for request : {}", req.getRequestURI());
+    }
+}

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -14,14 +14,17 @@
     	<Root level="DEBUG">
     		<AppenderRef ref="Console"/>
     	</Root>
-    	<Logger name="com.safetynet.safetynetalertsapi.services" additivity="true">
+    	<Logger name="com.safetynet.safetynetalertsapi.services" additivity="false">
     		<AppenderRef ref="REQUESTS_LOG"/>
     	</Logger>
-    	<Logger name="com.safetynet.safetynetalertsapi.repositories" additivity="true">
+    	<Logger name="com.safetynet.safetynetalertsapi.repositories" additivity="false">
     		<AppenderRef ref="REQUESTS_LOG"/>
     	</Logger>
-    	    	<Logger name="com.safetynet.safetynetalertsapi.controllers" additivity="true">
+		<Logger name="com.safetynet.safetynetalertsapi.controllers" additivity="false">
     		<AppenderRef ref="REQUESTS_LOG"/>
     	</Logger>
+		<Logger name="com.safetynet.safetynetalertsapi.config.filters" additivity="false">
+			<AppenderRef ref="REQUESTS_LOG"/>
+		</Logger>
     </Loggers>
 </Configuration>


### PR DESCRIPTION
Création de deux filtres de requêtes:
 - RequestResponseLoggingFilter: trace les requêtes et réponses HTTP;
 - TransactionFilter: journalise le début et la fin de chaque transaction.

Ajout d'un Logger dans la configuration de log4j2 a été adaptée pour permettre la journalisation dans /logs/requests.log.