### PR TITLE
nettoyage des classes du model

### DIFF
--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Address.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Address.java
@@ -21,24 +21,12 @@ public class Address {
 		return address;
 	}
 
-	public void setAddress(String address) {
-		this.address = address;
-	}
-
 	public String getCity() {
 		return city;
 	}
 
-	public void setCity(String city) {
-		this.city = city;
-	}
-
 	public String getZip() {
 		return zip;
-	}
-
-	public void setZip(String zip) {
-		this.zip = zip;
 	}
 	
 	public String toString() {

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Address.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Address.java
@@ -1,17 +1,17 @@
 package com.safetynet.safetynetalertsapi.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 public class Address {
 	private String address;
-	
+
 	private String city;
-	
+
 	private String zip;
 
-	public Address() {}
-
-	public Address(String address, String city, String zip) {
+	public Address(@JsonProperty("address") String address, @JsonProperty("city") String city, @JsonProperty("zip") String zip) {
 		this.address = address;
 		this.city = city;
 		this.zip = zip;
@@ -28,7 +28,7 @@ public class Address {
 	public String getZip() {
 		return zip;
 	}
-	
+
 	public String toString() {
 		return this.address + " " + this.city + " " + this.zip;
 	}

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/FireStation.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/FireStation.java
@@ -1,7 +1,6 @@
 package com.safetynet.safetynetalertsapi.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.safetynet.safetynetalertsapi.model.dto.FireStationDTO;
 
 import java.util.Objects;
 
@@ -17,14 +16,9 @@ import java.util.Objects;
  * - station: the identification number of the fire station
  */
 public class FireStation {
-    @JsonProperty("address")
     private String address;
 
-    @JsonProperty("station")
     private int station;
-
-    public FireStation() {
-    }
 
     public FireStation(@JsonProperty("address") String address, @JsonProperty("station") int station) {
         this.address = address;
@@ -35,16 +29,8 @@ public class FireStation {
         return station;
     }
 
-    public void setStation(int station) {
-        this.station = station;
-    }
-
     public String getAddress() {
         return address;
-    }
-
-    public void setAddress(String address) {
-        this.address = address;
     }
 
     @Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Identity.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Identity.java
@@ -1,7 +1,5 @@
 package com.safetynet.safetynetalertsapi.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 public class Identity {
@@ -12,7 +10,7 @@ public class Identity {
     public Identity() {
     }
 
-    public Identity(@JsonProperty("firstName") String firstName, @JsonProperty("lastName") String lastName) {
+    public Identity(String firstName, String lastName) {
         this.firstName = firstName;
         this.lastName = lastName;
     }
@@ -21,16 +19,8 @@ public class Identity {
         return firstName;
     }
 
-    public void setFirstName(String firstName) {
-        this.firstName = firstName;
-    }
-
     public String getLastName() {
         return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
     }
 
     @Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/MedicalRecord.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/MedicalRecord.java
@@ -7,15 +7,12 @@ import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import org.springframework.stereotype.Component;
 
 /**
  * Represents the medical record of a {@link Person} person in the SafetyNet Alerts system.
  * This class contains personal medical information such as the person's name, birth date,
  * allergies, and medications.
  */
-
-@Component
 public class MedicalRecord implements Identifiable {
     @JsonUnwrapped
     private Identity identity;
@@ -24,10 +21,8 @@ public class MedicalRecord implements Identifiable {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
     private LocalDate birthDate;
 
-    @JsonProperty("allergies")
     private List<String> allergies;
 
-    @JsonProperty("medications")
     private List<String> medications;
 
     public MedicalRecord() {
@@ -44,32 +39,16 @@ public class MedicalRecord implements Identifiable {
         return identity;
     }
 
-    public void setIdentity(Identity identity) {
-        this.identity = identity;
-    }
-
     public LocalDate getBirthDate() {
         return birthDate;
-    }
-
-    public void setBirthDate(LocalDate birthDate) {
-        this.birthDate = birthDate;
     }
 
     public List<String> getAllergies() {
         return allergies;
     }
 
-    public void setAllergies(List<String> allergies) {
-        this.allergies = allergies;
-    }
-
     public List<String> getMedications() {
         return medications;
-    }
-
-    public void setMedications(List<String> medications) {
-        this.medications = medications;
     }
 
     @Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Person.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Person.java
@@ -7,10 +7,10 @@ import java.util.Objects;
 /**
  * This class represents a person in the SafetyNet Alerts system.
  * It contains the personal information of individuals.
- * 
+ * <p>
  * The information includes the person's name, address, city, zip code, phone number,
  * and email address. This class is used to store and manage contact details for individuals in the system.
- * 
+ * </p>
  */
 public class Person implements Identifiable {	
 	@JsonUnwrapped

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/Person.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/Person.java
@@ -1,7 +1,5 @@
 package com.safetynet.safetynetalertsapi.model;
 
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import java.util.Objects;
@@ -21,10 +19,8 @@ public class Person implements Identifiable {
 	@JsonUnwrapped
 	private Address address;
 	
-	@JsonProperty("phone")
 	private String phone;
 	
-	@JsonProperty("email")
 	private String email;
 
 	public Person(Identity identity, Address address, String phone, String email) {
@@ -41,32 +37,16 @@ public class Person implements Identifiable {
 		return identity;
 	}
 	
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
-	}
-	
 	public Address getAddress() {
 		return address;
-	}
-	
-	public void setAddress(Address address) {
-		this.address = address;
 	}
 	
 	public String getPhone() {
 		return phone;
 	}
 	
-	public void setPhone(String phone) {
-		this.phone = phone;
-	}
-	
 	public String getEmail() {
 		return email;
-	}
-	
-	public void setEmail(String email) {
-		this.email = email;
 	}
 
 	@Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
@@ -33,21 +33,12 @@ public class AlertPersonInfoDTO implements Identifiable {
 	public int getAge() {
 		return age;
 	}
-	
-	public void setAge(int age) {
-		this.age = age;
-	}
-	
+
 	public List<String> getAllergies() {
 		return allergies;
 	}
 	
 	public List<String> getMedications() {
 		return medications;
-	}
-
-	@Override
-	public String toString() {
-		return this.getIdentity().toString();
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/AlertPersonInfoDTO.java
@@ -26,16 +26,8 @@ public class AlertPersonInfoDTO implements Identifiable {
 		return identity;
 	}
 	
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
-	}
-	
 	public String getPhone() {
 		return phone;
-	}
-	
-	public void setPhone(String phone) {
-		this.phone = phone;
 	}
 	
 	public int getAge() {
@@ -50,16 +42,8 @@ public class AlertPersonInfoDTO implements Identifiable {
 		return allergies;
 	}
 	
-	public void setAllergies(List<String> allergies) {
-		this.allergies = allergies;
-	}
-	
 	public List<String> getMedications() {
 		return medications;
-	}
-	
-	public void setMedications(List<String> medications) {
-		this.medications = medications;
 	}
 
 	@Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/ChildDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/ChildDTO.java
@@ -2,7 +2,6 @@ package com.safetynet.safetynetalertsapi.model.dto;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.safetynet.safetynetalertsapi.model.Identifiable;
 import com.safetynet.safetynetalertsapi.model.Identity;
@@ -13,7 +12,6 @@ public class ChildDTO implements Identifiable {
 	
 	private int age;
 	
-	@JsonProperty
 	@JsonUnwrapped
 	private List<FamilyMemberDTO> houseHoldMembers;
 	
@@ -26,25 +24,13 @@ public class ChildDTO implements Identifiable {
 	public Identity getIdentity() {
 		return identity;
 	}
-		
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
-	}
 
 	public int getAge() {
 		return age;
 	}
 	
-	public void setAge(int age) {
-		this.age = age;
-	}
-	
 	public List<FamilyMemberDTO> getHouseHoldMembers() {
 		return houseHoldMembers;
-	}
-	
-	public void setHouseHoldMembers(List<FamilyMemberDTO> houseHoldMembers) {
-		this.houseHoldMembers = houseHoldMembers;
 	}
 	
 	public String toString() {

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/CoveredPersonDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/CoveredPersonDTO.java
@@ -24,16 +24,8 @@ public class CoveredPersonDTO implements Identifiable {
 		return identity;
 	}
 
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
-	}
-
 	public String getAddress() {
 		return address.getAddress();
-	}
-
-	public void setAddress(Address address) {
-		this.address = address;
 	}
 
 	public String getPhone() {

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FamilyMemberDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FamilyMemberDTO.java
@@ -15,8 +15,4 @@ public class FamilyMemberDTO implements Identifiable {
 	public Identity getIdentity() {
 		return identity;
 	}
-
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
-	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireAlertDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireAlertDTO.java
@@ -15,15 +15,7 @@ public class FireAlertDTO {
 		return stationNumber;
 	}
 	
-	public void setStationNumber(int stationNumber) {
-		this.stationNumber = stationNumber;
-	}
-	
-	public List<AlertPersonInfoDTO> getResidents() {
+	public List<AlertPersonInfoDTO> getPersons() {
 		return persons;
-	}
-	
-	public void setResidents(List<AlertPersonInfoDTO> persons) {
-		this.persons = persons;
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationCoverageDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationCoverageDTO.java
@@ -2,6 +2,7 @@ package com.safetynet.safetynetalertsapi.model.dto;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FireStationCoverageDTO {
@@ -13,7 +14,8 @@ public class FireStationCoverageDTO {
 	
 	@JsonProperty("children")
 	long childrenCounter;
-	
+
+	@JsonCreator
 	public FireStationCoverageDTO(List<CoveredPersonDTO> coveredPersonsDTO, long adultsCounter, long children) {
 		this.coveredPersonsDTO = coveredPersonsDTO;
 		this.adultsCounter = adultsCounter;
@@ -24,23 +26,11 @@ public class FireStationCoverageDTO {
 		return coveredPersonsDTO;
 	}
 
-	public void setCoveredPersonsDTO(List<CoveredPersonDTO> coveredPersonsDTO) {
-		this.coveredPersonsDTO = coveredPersonsDTO;
-	}
-
 	public long getAdultsCounter() {
 		return adultsCounter;
 	}
 
-	public void setAdultsCounter(long adultsCounter) {
-		this.adultsCounter = adultsCounter;
-	}
-
 	public long getChildrenCounter() {
 		return childrenCounter;
-	}
-
-	public void setChildrenCounter(int childrenCounter) {
-		this.childrenCounter = childrenCounter;
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationCoverageDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationCoverageDTO.java
@@ -2,35 +2,29 @@ package com.safetynet.safetynetalertsapi.model.dto;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class FireStationCoverageDTO {
-	@JsonProperty("covered persons")
-	private List<CoveredPersonDTO> coveredPersonsDTO;
-	
-	@JsonProperty("adults")
-	long adultsCounter;
-	
-	@JsonProperty("children")
-	long childrenCounter;
+    @JsonProperty("covered persons")
+    private List<CoveredPersonDTO> coveredPersonsDTO;
+    long adults;
+    long children;
 
-	@JsonCreator
-	public FireStationCoverageDTO(List<CoveredPersonDTO> coveredPersonsDTO, long adultsCounter, long children) {
-		this.coveredPersonsDTO = coveredPersonsDTO;
-		this.adultsCounter = adultsCounter;
-		this.childrenCounter = children;
-	}
+    public FireStationCoverageDTO(List<CoveredPersonDTO> coveredPersonsDTO, long adults, long children) {
+        this.coveredPersonsDTO = coveredPersonsDTO;
+        this.adults = adults;
+        this.children = children;
+    }
 
-	public List<CoveredPersonDTO> getCoveredPersonsDTO() {
-		return coveredPersonsDTO;
-	}
+    public List<CoveredPersonDTO> getCoveredPersonsDTO() {
+        return coveredPersonsDTO;
+    }
 
-	public long getAdultsCounter() {
-		return adultsCounter;
-	}
+    public long getAdults() {
+        return adults;
+    }
 
-	public long getChildrenCounter() {
-		return childrenCounter;
-	}
+    public long getChildren() {
+        return children;
+    }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationDTO.java
@@ -1,7 +1,5 @@
 package com.safetynet.safetynetalertsapi.model.dto;
 
-import java.util.Objects;
-
 public class FireStationDTO {
 	private String address;
 	
@@ -23,14 +21,5 @@ public class FireStationDTO {
 	@Override
 	public String toString() {
 		return this.station + this.address;  
-	}
-
-	@Override
-	public boolean equals(Object object) {
-		if (this == object ) return true;
-		if (object == null || this.getClass() != object.getClass()) return false;
-		FireStationDTO fireStation = (FireStationDTO) object;
-		return Objects.equals(address, ((FireStationDTO) object).getAddress()) &&
-				Objects.equals(station, ((FireStationDTO) object).getStation());
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FireStationDTO.java
@@ -7,8 +7,6 @@ public class FireStationDTO {
 	
 	private int station;
 
-	public FireStationDTO() {}
-	
 	public FireStationDTO(String address, int station) {
 		this.address = address;
 		this.station = station;
@@ -17,17 +15,9 @@ public class FireStationDTO {
 	public int getStation() {
 		return station;
 	}
-	
-    public void setStation(int station) {
-        this.station = station;
-    }
 
 	public String getAddress() {
 		return address;
-	}
-
-	public void setAddress(String address) {
-		this.address = address;
 	}
 	
 	@Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FloodAlertDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/FloodAlertDTO.java
@@ -16,15 +16,8 @@ public class FloodAlertDTO {
         return address;
     }
 
-    public void setAddress(String address) {
-        this.address = address;
-    }
 
     public List<AlertPersonInfoDTO> getPersons() {
         return persons;
-    }
-
-    public void setPersons(List<AlertPersonInfoDTO> persons) {
-        this.persons = persons;
     }
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/MedicalRecordDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/MedicalRecordDTO.java
@@ -4,12 +4,10 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.safetynet.safetynetalertsapi.model.Identity;
-import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
 import java.util.List;
 
-@Component
 public class MedicalRecordDTO {
 
     public MedicalRecordDTO() {
@@ -29,10 +27,8 @@ public class MedicalRecordDTO {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "MM/dd/yyyy")
     private LocalDate birthDate;
 
-    @JsonProperty("allergies")
     private List<String> allergies;
 
-    @JsonProperty("medications")
     private List<String> medications;
 
     public Identity getIdentity() {
@@ -47,24 +43,12 @@ public class MedicalRecordDTO {
         return birthDate;
     }
 
-    public void setBirthDate(LocalDate birthDate) {
-        this.birthDate = birthDate;
-    }
-
     public List<String> getAllergies() {
         return allergies;
     }
 
-    public void setAllergies(List<String> allergies) {
-        this.allergies = allergies;
-    }
-
     public List<String> getMedications() {
         return medications;
-    }
-
-    public void setMedications(List<String> medications) {
-        this.medications = medications;
     }
 
     @Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/PersonDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/PersonDTO.java
@@ -29,32 +29,16 @@ public class PersonDTO implements Identifiable {
 		return identity;
 	}
 	
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
-	}
-	
 	public Address getAddress() {
 		return address;
-	}
-	
-	public void setAddress(Address address) {
-		this.address = address;
 	}
 	
 	public String getPhone() {
 		return phone;
 	}
 	
-	public void setPhone(String phone) {
-		this.phone = phone;
-	}
-	
 	public String getEmail() {
 		return email;
-	}
-	
-	public void setEmail(String email) {
-		this.email = email;
 	}
 	
 	@Override

--- a/src/main/java/com/safetynet/safetynetalertsapi/model/dto/PersonInfoDTO.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/model/dto/PersonInfoDTO.java
@@ -25,52 +25,27 @@ public class PersonInfoDTO {
 		this.medications = medications;
 	}
 
-	
 	public Identity getIdentity() {
 		return identity;
-	}
-
-	public void setIdentity(Identity identity) {
-		this.identity = identity;
 	}
 
 	public Address getAddress() {
 		return address;
 	}
 
-	public void setAddress(Address address) {
-		this.address = address;
-	}
-
 	public int getAge() {
 		return age;
 	}
 
-	public void setAge(int age) {
-		this.age = age;
-	}
-
 	public String getEmail() {
 		return email;
-	}
-
-	public void setEmail(String email) {
-		this.email = email;
 	}
 	
 	public List<String> getAllergies() {
 		return allergies;
 	}
 	
-	public void setAllergies(List<String> allergies) {
-		this.allergies = allergies;
-	}
-	
 	public List<String> getMedications() {
 		return medications;
-	}
-	
-	public void setMedications(List<String> medications) {
-		this.medications = medications;
 	}
 }

--- a/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/MedicalRecordMapper.java
+++ b/src/main/java/com/safetynet/safetynetalertsapi/services/mappers/MedicalRecordMapper.java
@@ -2,19 +2,10 @@ package com.safetynet.safetynetalertsapi.services.mappers;
 
 import com.safetynet.safetynetalertsapi.model.MedicalRecord;
 import com.safetynet.safetynetalertsapi.model.dto.MedicalRecordDTO;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MedicalRecordMapper {
-    @Autowired
-    MedicalRecord medicalRecord;
-
-    @Autowired
-    MedicalRecordDTO medicalRecordDTO;
-
     public MedicalRecordDTO fromMedicalRecordToMedicalRecordDto(MedicalRecord medicalRecord) {
         return new MedicalRecordDTO(medicalRecord.getIdentity(), medicalRecord.getBirthDate(), medicalRecord.getAllergies(), medicalRecord.getMedications());
     }

--- a/src/test/java/com/safetynet/safetynetalertsapi/controllers/FireStationControllerTest.java
+++ b/src/test/java/com/safetynet/safetynetalertsapi/controllers/FireStationControllerTest.java
@@ -119,10 +119,10 @@ public class FireStationControllerTest {
         mockMvc.perform(get("/fire/1509culverst"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.stationNumber").isNumber())
-                .andExpect(jsonPath("$.residents").isArray())
-                .andExpect(jsonPath("$.residents[0].age").isNumber())
-                .andExpect(jsonPath("$.residents[0].allergies").isArray())
-                .andExpect(jsonPath("$.residents[0].medications").isArray());
+                .andExpect(jsonPath("$.persons").isArray())
+                .andExpect(jsonPath("$.persons[0].age").isNumber())
+                .andExpect(jsonPath("$.persons[0].allergies").isArray())
+                .andExpect(jsonPath("$.persons[0].medications").isArray());
     }
 
     /**
@@ -208,7 +208,6 @@ public class FireStationControllerTest {
      */
     @Test
     public void testUpdateFireStationShouldFailWithUnkownAddress() throws Exception {
-        String json = "{\"address\": \"29 15th St\", \"station\": 3}";
         mockMvc.perform(put("/firestation/2915thStsss"))
                 .andExpect(status().is4xxClientError());
     }
@@ -223,8 +222,9 @@ public class FireStationControllerTest {
     }
 
     /**
-     * Test DELETE /firestation/{address} to delete a fire station.
-     *
+     * Test DELETE /firestation/{stationNumber}/{address} to delete a fire station.
+     * <p>Should return 404 Not Found because the given address is not associated
+     * with the given station number.</p>
      */
     @Test void testDeleteFireStationShouldReturnNotFound() throws Exception {
         mockMvc.perform(delete("/firestation/6/maplestreet")


### PR DESCRIPTION
Simplification des classes du model : 

La classe Address a un constructeur annoté pour éviter les erreurs de dérérialisation liées à des conflits avec l'annotation @JsonUnwrapped. 

Les setters ont été retirés pour alléger le code puisque Jackson utilise les getters et les constructeurs des objets du model. 
Les méthodes inutilisés (hashCode(), equals()... ) ont été supprimées. 